### PR TITLE
Temporary fix: not found vias.

### DIFF
--- a/replicate_layout/replicatelayout.py
+++ b/replicate_layout/replicatelayout.py
@@ -331,6 +331,8 @@ class Replicator:
                 # https://github.com/mmccoo/kicad_mmccoo/blob/master/replicatelayout/replicatelayout.py
                 if track.GetClass() == "VIA":
                     oldvia = self.board.GetViaByPosition(track.GetPosition())
+                    if oldvia is None:
+                        continue
                     newvia = pcbnew.VIA(self.board)
                     # need to add before SetNet will work, so just doing it first
                     self.board.Add(newvia)


### PR DESCRIPTION
It seems that in some occasions, GetViaByPosition(track.GetPosition()) (line 333) returns NoneType. The proposed change will stop the script from crashing, but also won't correctly replicate those vias. I don't know how to properly fix this, but this at least makes the script usable again for me.