### PR TITLE
Clear the group setting for replicate_layout buttons

### DIFF
--- a/replicate_layout/action_replicate_layout.py
+++ b/replicate_layout/action_replicate_layout.py
@@ -39,7 +39,7 @@ class ReplicateLayoutDialog(wx.Dialog):
         self.rad_btn_Linear.SetValue(True)
         bSizer9.Add( self.rad_btn_Linear, 0, wx.ALL, 5 )
 
-        self.rad_btn_Circular = wx.RadioButton( self, wx.ID_ANY, u"Circular", wx.DefaultPosition, wx.DefaultSize, wx.RB_GROUP )
+        self.rad_btn_Circular = wx.RadioButton( self, wx.ID_ANY, u"Circular", wx.DefaultPosition, wx.DefaultSize )
         self.rad_btn_Circular.SetValue(False)
         bSizer9.Add( self.rad_btn_Circular, 0, wx.ALL, 5 )
 


### PR DESCRIPTION
The radio buttons are grouped by setting the first element of the group
to wx.RB_GROUP.  Setting multiple radio buttons with this flag causes
them all to be selected at the same time under Linux.