### PR TITLE
Replicate layout: allow text objects to be replicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ Basic requirement for replication is that the section for replication is complet
 ![Top sheet schematics](https://raw.githubusercontent.com/MitjaNemec/Kicad_action_plugins/master/screenshots/Replicate_layout_0.png)
 ![Hierarchical sheet to replicate](https://raw.githubusercontent.com/MitjaNemec/Kicad_action_plugins/master/screenshots/Replicate_layout_1.png)
 
-Once the section for replication (pivot section) has been laid out (modules, tracks and zones placed) you need to:
+Once the section for replication (pivot section) has been laid out (modules, tracks, text objects and zones placed) you need to:
 1. select anyone of the modules within the pivot section
 2. run the plugin
 3. choose between linear and circular replication
 4. Enter replication step size (x,y in linear replication and radius, angle (in degrees) for circular replication
-5. select wheather you want to replicate also tracks and/or zones
-6. select wheather you want to replicate tracks/zones which are intersectin the pivot bounding box
-7. select wheather you want to delete already layed out tracks/zones (this is useful when updating already replicated layout)
+5. select whether you want to replicate also tracks, zones and/or text objects
+6. select whether you want to replicate tracks/zones/text which intersect the pivot bounding box or just those contained within the bounding box
+7. select whether you want to delete already layed out tracks/zones/text (this is useful when updating already replicated layout)
 8. hit OK
 
 The replication can be linear or circular. For linear replication the plugin will ask for x and y offset (in mm) with respect to pivot section where replicated sections will be placed. For circular replication the plugin will ask for radius (in mm) and angle (in °) with respect to pivot section where replicated sections will be placed.
 
-Additionally you can choose wheather you want to replicate also zones and/or tracks. By default only tracks and zones which are contained in bounding box constituted by all the modules in the section will be replicated. You can seledt to replicate also zones and tracks which intersect this bounding box. Additionally, tracks and zones already laid out in replicated bounding boxes can be removed (useful when updating). Note that in circular replication, bounding boxes are still squares alligned with x and y axis.
+Additionally you can choose wheather you want to replicate also zones, text and/or tracks. By default only objects which are contained in bounding box constituted by all the modules in the section will be replicated. You can select to replicate also zones and tracks which intersect this bounding box. Additionally, tracks, text and zones already laid out in replicated bounding boxes can be removed (useful when updating). Note that in circular replication, bounding boxes are still squares alligned with x and y axis.
 
 ![Bounding box, contained, intersecting definitions](https://raw.githubusercontent.com/MitjaNemec/Kicad_action_plugins/master/screenshots/Replicate_layout_2.png)
 

--- a/replicate_layout/action_replicate_layout.py
+++ b/replicate_layout/action_replicate_layout.py
@@ -83,6 +83,14 @@ class ReplicateLayoutDialog(wx.Dialog):
 
         bSizer1.Add( bSizer5, 1, wx.EXPAND, 5 )
 
+        bSizer6 = wx.BoxSizer( wx.HORIZONTAL )
+
+        self.chkbox_text = wx.CheckBox( self, wx.ID_ANY, u"Replicate text", wx.DefaultPosition, wx.DefaultSize, 0 )
+        self.chkbox_text.SetValue(True)
+        bSizer6.Add( self.chkbox_text, 0, wx.ALL, 5 )
+
+        bSizer1.Add( bSizer6, 1, wx.EXPAND, 5 )
+
         bSizer10 = wx.BoxSizer( wx.HORIZONTAL )
 
         self.chkbox_intersecting = wx.CheckBox( self, wx.ID_ANY, u"Replicate intersecting tracks/zones", wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -193,6 +201,7 @@ class ReplicateLayout(pcbnew.ActionPlugin):
 
             replicate_containing_only = False
             remove_existing_nets_zones = False
+            rep_text = False
             rep_tracks = False
             rep_zones = False
 
@@ -210,6 +219,7 @@ class ReplicateLayout(pcbnew.ActionPlugin):
                 remove_existing_nets_zones = dlg.chkbox_remove.GetValue()
                 rep_tracks = dlg.chkbox_tracks.GetValue()
                 rep_zones = dlg.chkbox_zones.GetValue()
+                rep_text = dlg.chkbox_text.GetValue()
             else:
                 process_canceled = True
 
@@ -226,7 +236,7 @@ class ReplicateLayout(pcbnew.ActionPlugin):
                                                 replicate_containing_only,
                                                 remove_existing_nets_zones,
                                                 rep_tracks,
-                                                rep_zones,
+                                                rep_zones, rep_text,
                                                 polar)
 
                     pcbnew.Refresh()

--- a/replicate_layout/dialog_layout.fbp
+++ b/replicate_layout/dialog_layout.fbp
@@ -854,6 +854,105 @@
                     <property name="proportion">1</property>
                     <object class="wxBoxSizer" expanded="1">
                         <property name="minimum_size"></property>
+                        <property name="name">bSizer6</property>
+                        <property name="orient">wxHORIZONTAL</property>
+                        <property name="permission">none</property>
+                        <object class="sizeritem" expanded="1">
+                            <property name="border">5</property>
+                            <property name="flag">wxALL</property>
+                            <property name="proportion">0</property>
+                            <object class="wxCheckBox" expanded="1">
+                                <property name="BottomDockable">1</property>
+                                <property name="LeftDockable">1</property>
+                                <property name="RightDockable">1</property>
+                                <property name="TopDockable">1</property>
+                                <property name="aui_layer"></property>
+                                <property name="aui_name"></property>
+                                <property name="aui_position"></property>
+                                <property name="aui_row"></property>
+                                <property name="best_size"></property>
+                                <property name="bg"></property>
+                                <property name="caption"></property>
+                                <property name="caption_visible">1</property>
+                                <property name="center_pane">0</property>
+                                <property name="checked">1</property>
+                                <property name="close_button">1</property>
+                                <property name="context_help"></property>
+                                <property name="context_menu">1</property>
+                                <property name="default_pane">0</property>
+                                <property name="dock">Dock</property>
+                                <property name="dock_fixed">0</property>
+                                <property name="docking">Left</property>
+                                <property name="enabled">1</property>
+                                <property name="fg"></property>
+                                <property name="floatable">1</property>
+                                <property name="font"></property>
+                                <property name="gripper">0</property>
+                                <property name="hidden">0</property>
+                                <property name="id">wxID_ANY</property>
+                                <property name="label">Replicate text</property>
+                                <property name="max_size"></property>
+                                <property name="maximize_button">0</property>
+                                <property name="maximum_size"></property>
+                                <property name="min_size"></property>
+                                <property name="minimize_button">0</property>
+                                <property name="minimum_size"></property>
+                                <property name="moveable">1</property>
+                                <property name="name">chkbox_text</property>
+                                <property name="pane_border">1</property>
+                                <property name="pane_position"></property>
+                                <property name="pane_size"></property>
+                                <property name="permission">protected</property>
+                                <property name="pin_button">1</property>
+                                <property name="pos"></property>
+                                <property name="resize">Resizable</property>
+                                <property name="show">1</property>
+                                <property name="size"></property>
+                                <property name="style"></property>
+                                <property name="subclass">; forward_declare</property>
+                                <property name="toolbar_pane">0</property>
+                                <property name="tooltip"></property>
+                                <property name="validator_data_type"></property>
+                                <property name="validator_style">wxFILTER_NONE</property>
+                                <property name="validator_type">wxDefaultValidator</property>
+                                <property name="validator_variable"></property>
+                                <property name="window_extra_style"></property>
+                                <property name="window_name"></property>
+                                <property name="window_style"></property>
+                                <event name="OnChar"></event>
+                                <event name="OnCheckBox"></event>
+                                <event name="OnEnterWindow"></event>
+                                <event name="OnEraseBackground"></event>
+                                <event name="OnKeyDown"></event>
+                                <event name="OnKeyUp"></event>
+                                <event name="OnKillFocus"></event>
+                                <event name="OnLeaveWindow"></event>
+                                <event name="OnLeftDClick"></event>
+                                <event name="OnLeftDown"></event>
+                                <event name="OnLeftUp"></event>
+                                <event name="OnMiddleDClick"></event>
+                                <event name="OnMiddleDown"></event>
+                                <event name="OnMiddleUp"></event>
+                                <event name="OnMotion"></event>
+                                <event name="OnMouseEvents"></event>
+                                <event name="OnMouseWheel"></event>
+                                <event name="OnPaint"></event>
+                                <event name="OnRightDClick"></event>
+                                <event name="OnRightDown"></event>
+                                <event name="OnRightUp"></event>
+                                <event name="OnSetFocus"></event>
+                                <event name="OnSize"></event>
+                                <event name="OnUpdateUI"></event>
+                            </object>
+                        </object>
+                    </object>
+                </object>
+                <object class="sizeritem" expanded="1">
+                    <property name="border">5</property>
+                    <property name="flag">wxEXPAND</property>
+                    <property name="proportion">1</property>
+                    <object class="wxBoxSizer" expanded="1">
+                        <property name="minimum_size"></property>
                         <property name="name">bSizer10</property>
                         <property name="orient">wxHORIZONTAL</property>
                         <property name="permission">none</property>


### PR DESCRIPTION
Adds support for replicating standalone text objects (i.e., text not
associated with a footprint such as a reference). This is a separate
option in the dialog box (defaults to on) and includes support for
removing existing text objects from the zones to be cloned.