### PR TITLE
Possible correction to Assertion "aNetInfo->GetBoard() == GetBoard()" failed.

### DIFF
--- a/save_restore_layout/save_restore_layout.py
+++ b/save_restore_layout/save_restore_layout.py
@@ -607,9 +607,20 @@ class RestoreLayout():
                 new_track = track.Duplicate()
                 new_track.Rotate(mod1_pos, delta_orientation)
                 new_track.Move(move_vector)
-                logger.info("Setting track net to: " + repr(to_net_code) + ", " + repr(to_net_name))
-                new_track.SetNetCode(to_net_code)
-                new_track.SetNet(to_net_item)
+                logger.info("new_track: " + repr(type(new_track)) + ", " + repr(dir(new_track)))
+                brd_net = self.board.FindNet(to_net_name)
+                if brd_net:
+                    logger.info('Setting track: found brd_net '+str(brd_net.GetNet()))
+                    new_track.SetNetCode(brd_net.GetNet())
+                    #new_track.SetNet(brd_net)  # assert crash at first track
+                else:
+                    # might not be needed
+                    logger.info('Setting track: NOT found brd_net '+to_net_name)
+                    net = pcbnew.NETINFO_ITEM(self.board, to_net_name)
+                    self.board.AppendNet(net)
+                    new_track.SetNetCode(net.GetNet())
+                    #new_track.SetNet(net)
+
                 self.board.Add(new_track)
 
     def replicate_zones(self, pivot_anchor_mod, pivot_zones, anchor_mod, net_pairs):

--- a/save_restore_layout/save_restore_layout.py
+++ b/save_restore_layout/save_restore_layout.py
@@ -605,23 +605,12 @@ class RestoreLayout():
 
                 # make a duplicate, move it, rotate it, select proper net and add it to the board
                 new_track = track.Duplicate()
+                self.board.Add(new_track)
                 new_track.Rotate(mod1_pos, delta_orientation)
                 new_track.Move(move_vector)
                 logger.info("Setting track net to: " + repr(to_net_code) + ", " + repr(to_net_name))
-                brd_net = self.board.FindNet(to_net_name)
-                if brd_net:
-                    logger.info('Setting track: found brd_net '+str(brd_net.GetNet()))
-                    new_track.SetNetCode(brd_net.GetNet())
-                    #new_track.SetNet(brd_net)  # assert crash at first track
-                else:
-                    # might not be needed
-                    logger.info('Setting track: NOT found brd_net '+to_net_name)
-                    net = pcbnew.NETINFO_ITEM(self.board, to_net_name)
-                    self.board.AppendNet(net)
-                    new_track.SetNetCode(net.GetNet())
-                    #new_track.SetNet(net)
-
-                self.board.Add(new_track)
+                new_track.SetNetCode(to_net_code)
+                new_track.SetNet(to_net_item)  # assert crash if board.Add after this line
 
     def replicate_zones(self, pivot_anchor_mod, pivot_zones, anchor_mod, net_pairs):
         """ method which replicates zones"""
@@ -672,11 +661,11 @@ class RestoreLayout():
 
             # make a duplicate, move it, rotate it, select proper net and add it to the board
             new_zone = zone.Duplicate()
+            self.board.Add(new_zone)
             new_zone.Rotate(mod1_pos, delta_orientation)
             new_zone.Move(move_vector)
             new_zone.SetNetCode(to_net_code)
-            new_zone.SetNet(to_net_item)
-            self.board.Add(new_zone)
+            new_zone.SetNet(to_net_item) # assert crash if board.Add after this line
 
     def replicate_text(self, pivot_anchor_mod, pivot_text, anchor_mod):
         logger.info("Replicating text")

--- a/save_restore_layout/save_restore_layout.py
+++ b/save_restore_layout/save_restore_layout.py
@@ -607,7 +607,7 @@ class RestoreLayout():
                 new_track = track.Duplicate()
                 new_track.Rotate(mod1_pos, delta_orientation)
                 new_track.Move(move_vector)
-                logger.info("new_track: " + repr(type(new_track)) + ", " + repr(dir(new_track)))
+                logger.info("Setting track net to: " + repr(to_net_code) + ", " + repr(to_net_name))
                 brd_net = self.board.FindNet(to_net_name)
                 if brd_net:
                     logger.info('Setting track: found brd_net '+str(brd_net.GetNet()))


### PR DESCRIPTION
This works on my debian-testing machine, but crash with another assertion.

kicad: /build/kicad-2BBSqv/kicad-5.1.4+dfsg1/pcbnew/board_connected_item.cpp:69: bool BOARD_CONNECTED_ITEM::SetNetCode(int, bool): Assertion `m_netinfo' failed.

the board I'm using: save_restore_layout/Source_project/multiple_hierarchy.kicad_pcb

  1-load board
  2-select part U1301
  3- run save_restore_layout
  4- choose restore
  5- choose Power.pckl
  6- crash with Assertion `m_netinfo' failed.

[save_restore_layout.log](https://github.com/MitjaNemec/Kicad_action_plugins/files/3705399/save_restore_layout.log)

This is all I can do for now, it's going late.
