### PR TITLE
Replicate "Keep Upright" as well

### DIFF
--- a/replicate_layout/replicatelayout.py
+++ b/replicate_layout/replicatelayout.py
@@ -680,6 +680,7 @@ class Replicator():
                     mod_text_items[index].SetMultilineAllowed(pivot_text.IsMultilineAllowed())
                     mod_text_items[index].SetHorizJustify(pivot_text.GetHorizJustify())
                     mod_text_items[index].SetVertJustify(pivot_text.GetVertJustify())
+                    mod_text_items[index].SetKeepUpright(pivot_text.IsKeepUpright())
                     # set visibility
                     mod_text_items[index].SetVisible(pivot_text.IsVisible())
 


### PR DESCRIPTION
This is necessary for (left,right)-justified text that gets rotated on
replication. The text will flow in the wrong direction otherwise.