### PR TITLE
Read schematic files as UTF-8

### DIFF
--- a/replicate_layout/replicatelayout.py
+++ b/replicate_layout/replicatelayout.py
@@ -110,7 +110,7 @@ def get_module_text_items(module):
 class Replicator():
     @staticmethod
     def extract_subsheets(filename):
-        with open(filename) as f:
+        with open(filename, encoding='utf-8') as f:
             file_folder = os.path.dirname(os.path.abspath(filename))
             file_lines = f.read()
         # alternative solution


### PR DESCRIPTION
This allows for UTF-8 in schematic files. As ASCII is also valid UTF-8,
this is a non-breaking change.

I think applying the same change to https://github.com/MitjaNemec/Kicad_action_plugins/blob/master/save_restore_layout/save_restore_layout.py#L188 should help with #85, but as I don't use `save_restore_layout` I couldn't verify this.
