### PR TITLE
5.99: remove .strip() from UUID to preserve leading zeros

### DIFF
--- a/replicate_layout/replicatelayout.py
+++ b/replicate_layout/replicatelayout.py
@@ -139,8 +139,8 @@ class Replicator():
         for fp in bmod:
             mod_path = fp.GetPath()
             s = mod_path.size()
-            mod_id = mod_path.__getitem__(s-1).AsString().strip('00000000-0000-0000-0000-0000')
-            sheet_id = mod_path.__getitem__(s-2).AsString().strip('00000000-0000-0000-0000-0000')
+            mod_id = mod_path.__getitem__(s-1).AsString()
+            sheet_id = mod_path.__getitem__(s-2).AsString()
             sheet_file = fp.GetProperty('Sheetfile')
             sheet_name = fp.GetProperty('Sheetname')
             if sheet_file:


### PR DESCRIPTION
searching for hierarchical sheet filenames fails if the UUID contains a leading zero, which is stripped in `self.dict_of_sheets`, and not in other places like [here](https://github.com/MitjaNemec/Kicad_action_plugins/blob/5.99_test/replicate_layout/replicatelayout.py#L113)

this removes this, which should not be necessary anyways, as far as i can tell the UUIDs are always taken from the schematic file, and can probably be assumed to be of consistent format/string-representation.